### PR TITLE
Converts ES7 syntax to ES6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-react-task
-==========
+# react-task
 
 The minimal dev environment to enable live-editing React components.
 
-### Usage
+## Usage
 
 ```
 npm install
@@ -11,15 +10,15 @@ npm start
 open http://localhost:3000
 ```
 
-### Task
+## Task
 
-* Please add pagination support to the list when there are more than 2 entries
-* Please add option to select sex of a friend male/female and  display it
-* Please add tests unsing your preferred testing tool (mocha, should.js ...)
+- Please add pagination support to the list when there are more than 2 entries
+- Please add option to select sex of a friend male/female and display it
+- Please add tests using your preferred testing tool (mocha, should.js ...)
 
-### Objectives
+## Objectives
 
-* You have received a working example so please do not upgrade any packages unless you really have to.
-* Please check for small things like syntax errors, since details matter.
-* Please deliver something that works, non working project is an automatic disqualification
-* Try to complete as many tasks as you can
+- You have received a working example so please do not upgrade any packages unless you really have to.
+- Please check for small things like syntax errors, since details matter.
+- Please deliver something that works, non working project is an automatic disqualification
+- Try to complete as many tasks as you can

--- a/src/components/AddFriendInput.js
+++ b/src/components/AddFriendInput.js
@@ -2,10 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
 import styles from './AddFriendInput.css';
 
-export default class AddFriendInput extends Component {
-  static propTypes = {
-    addFriend: PropTypes.func.isRequired
-  }
+class AddFriendInput extends Component {
 
   render () {
     return (
@@ -40,3 +37,9 @@ export default class AddFriendInput extends Component {
   }
 
 }
+
+AddFriendInput.propTypes = {
+  addFriend: PropTypes.func.isRequired
+}
+
+export default AddFriendInput

--- a/src/components/FriendList.js
+++ b/src/components/FriendList.js
@@ -4,11 +4,7 @@ import mapValues from 'lodash/object/mapValues';
 import styles from './FriendList.css';
 import FriendListItem from './FriendListItem';
 
-export default class FriendList extends Component {
-  static propTypes = {
-    friends: PropTypes.object.isRequired,
-    actions: PropTypes.object.isRequired
-  }
+class FriendList extends Component {
 
   render () {
     return (
@@ -28,3 +24,10 @@ export default class FriendList extends Component {
   }
 
 }
+
+FriendList.propTypes = {
+  friends: PropTypes.object.isRequired,
+  actions: PropTypes.object.isRequired
+}
+
+export default FriendList

--- a/src/components/FriendListItem.js
+++ b/src/components/FriendListItem.js
@@ -2,14 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
 import styles from './FriendListItem.css';
 
-export default class FriendListItem extends Component {
-  static propTypes = {
-    id: PropTypes.number.isRequired,
-    name: PropTypes.string.isRequired,
-    starred: PropTypes.boolean,
-    starFriend: PropTypes.func.isRequired,
-    onTrashClick: PropTypes.func.isRequired
-  }
+class FriendListItem extends Component {
 
   render () {
     return (
@@ -31,3 +24,13 @@ export default class FriendListItem extends Component {
   }
 
 }
+
+FriendListItem.propTypes = {
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  starred: PropTypes.boolean,
+  starFriend: PropTypes.func.isRequired,
+  onTrashClick: PropTypes.func.isRequired
+}
+
+export default FriendListItem

--- a/src/containers/FriendListApp.js
+++ b/src/containers/FriendListApp.js
@@ -9,9 +9,7 @@ import { FriendList, AddFriendInput } from '../components';
 class FriendListApp extends Component {
 
   render () {
-    console.log(this.props)
     const { friendlist: { friendsById }, dispatch } = this.props;
-    console.log(friendsById)
     const actions = bindActionCreators(FriendsActions, dispatch);
 
     return (

--- a/src/containers/FriendListApp.js
+++ b/src/containers/FriendListApp.js
@@ -6,18 +6,12 @@ import { connect } from 'react-redux';
 import * as FriendsActions from '../actions/FriendsActions';
 import { FriendList, AddFriendInput } from '../components';
 
-@connect(state => ({
-  friendlist: state.friendlist
-}))
-export default class FriendListApp extends Component {
-
-  static propTypes = {
-    friendsById: PropTypes.object.isRequired,
-    dispatch: PropTypes.func.isRequired
-  }
+class FriendListApp extends Component {
 
   render () {
+    console.log(this.props)
     const { friendlist: { friendsById }, dispatch } = this.props;
+    console.log(friendsById)
     const actions = bindActionCreators(FriendsActions, dispatch);
 
     return (
@@ -29,3 +23,14 @@ export default class FriendListApp extends Component {
     );
   }
 }
+
+FriendListApp.propTypes = {
+  friendsById: PropTypes.object.isRequired,
+  dispatch: PropTypes.func.isRequired
+}
+
+function mapStateToProps(state) {
+  return state
+}
+
+export default connect(mapStateToProps)(FriendListApp)


### PR DESCRIPTION
Some files use ES7 syntax (e.g. property initializers) leading to built errors.
Babel5 (as specified in the package.json) doesn't support ES7 and packages aren't supposed to be upgraded, so I converted the ES7 syntax to ES6.
Also fixed a typo in the Readme. 😉